### PR TITLE
gnutls: Add MIRRORS

### DIFF
--- a/meta-webos/recipes-upstreamable/gnutls/gnutls_3.3.27.bb
+++ b/meta-webos/recipes-upstreamable/gnutls/gnutls_3.3.27.bb
@@ -5,6 +5,8 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504 \
 
 FILESEXTRAPATHS_prepend = "${COREBASE}/meta/recipes-support/${BPN}/${BPN}:"
 
+MIRRORS += "ftp://ftp.gnutls.org/gcrypt/gnutls ${GNUPG_MIRROR}/gnutls \n"
+
 SRC_URI += " \
     file://correct_rpl_gettimeofday_signature.patch \
     file://configure.ac-fix-sed-command.patch \


### PR DESCRIPTION
FTP mirror seems to randomly give issues for some users, therefore add the HTTPS mirror. Similar fix has been applied upstream in the mirrors.bbclass

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>