### PR TITLE
Update webos-connman-adapter.sh: Only load cdc_ether in case it's bui…

### DIFF
--- a/meta-webos/recipes-webos/webos-connman-adapter/webos-connman-adapter/webos-connman-adapter.sh
+++ b/meta-webos/recipes-webos/webos-connman-adapter/webos-connman-adapter/webos-connman-adapter.sh
@@ -15,6 +15,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# First, if the cdc_ether isn't built as a module, there's nothing to do
+if ! zgrep -qs CONFIG_USB_NET_CDCETHER=m /proc/config.gz; then
+    exit 0
+fi
+
 # To provide enough time for inbuilt adapter to be configured
 
 if ! grep -qs qemu /etc/hostname ; then


### PR DESCRIPTION
…lt as module

On targets outside of OSE such as LuneOS targets which use Android or Mainline Kernel, CDC_ETHER might not be built (as module), so introduce a check, to make sure that it's actually built as module, before trying to modprobe it.

Solves a continuous loop.