### PR TITLE
update webos.inc and webos_ls2_api_list.bbclass

### DIFF
--- a/meta-webos/classes/webos_ls2_api_list.bbclass
+++ b/meta-webos/classes/webos_ls2_api_list.bbclass
@@ -102,8 +102,10 @@ python do_write_ls2_api_list() {
     bb.note("webOS Distro Name ::: " + d.getVar('DISTRO'))
     ls_api_info= {'ls2_api_list': ls_api_info_data, 'release_code_name': d.getVar('WEBOS_DISTRO_RELEASE_CODENAME'), 'distro': d.getVar('DISTRO')}
 
-    #write ls_api_info to file
     ls2_output_file = d.getVar("LS2_API_LIST_FILENAME")
+    if not (d.getVar('BUILDHISTORY_DIR_IMAGE') and os.path.isdir(d.getVar('BUILDHISTORY_DIR_IMAGE'))):
+        bb.warn("BUILDHISTORY_DIR_IMAGE '%s' is empty or isn't a directory (probably buildhistory isn't enabled), will not create %s file there" % (d.getVar('BUILDHISTORY_DIR_IMAGE'), ls2_output_file))
+        return
     output = os.path.join(d.getVar('BUILDHISTORY_DIR_IMAGE'), ls2_output_file)
     json_info_as_string = json.dumps(ls_api_info).replace("'", '"')
     with open(output, 'w') as f:

--- a/meta-webos/conf/distro/include/webos.inc
+++ b/meta-webos/conf/distro/include/webos.inc
@@ -461,6 +461,20 @@ PACKAGE_ADD_METADATA = "Author: ${PACKAGE_ADD_AUTHOR_METADATA}\nRP-Maintainer: $
 PACKAGE_ADD_RECIPES_METADATA ?= ""
 PACKAGE_ADD_METADATA .= "\n${PACKAGE_ADD_RECIPES_METADATA}"
 
+# Avoid adding these fields to RPM and DEP
+# breaking RPM builds as shown in http://errors.yoctoproject.org/Errors/Details/751706/
+PACKAGE_ADD_METADATA_RPM = ""
+PACKAGE_ADD_METADATA_DEP = ""
+
+# To support these fields with opkg package-index where it causes a lot of "Lost field" messages
+# we need to pass -f to opkg-make-index as it was added in:
+# https://git.yoctoproject.org/opkg-utils/commit/opkg-make-index?id=13f6281d24e17199e0fef6c2984419372ea0f86f
+# but there is no simple way to add -f in kirkstone, for scarthgap and newer it will implemented soon with:
+# https://lists.openembedded.org/g/openembedded-core/message/194813
+# https://lists.openembedded.org/g/openembedded-core/message/194814
+OPKG_MAKE_INDEX_EXTRA_PARAMS = "-f"
+RPMBUILD_EXTRA_PARAMS = " --define '_Author Author' --define '_RP-Maintainer RP-Maintainer' --define '_Recipes Recipes'"
+
 # Set ccache configuration from <top layer>/conf/ccache.conf
 export CCACHE_CONFIGPATH = "${@bb.utils.which('${BBPATH}', 'conf/ccache.conf')}"
 export CCACHE_COMPILERCHECK = "content"

--- a/meta-webos/conf/distro/include/webos.inc
+++ b/meta-webos/conf/distro/include/webos.inc
@@ -461,6 +461,9 @@ PACKAGE_ADD_METADATA = "Author: ${PACKAGE_ADD_AUTHOR_METADATA}\nRP-Maintainer: $
 PACKAGE_ADD_RECIPES_METADATA ?= ""
 PACKAGE_ADD_METADATA .= "\n${PACKAGE_ADD_RECIPES_METADATA}"
 
+# Force PACKAGE_CLASSES to IPK, currently webOS support IPK only
+PACKAGE_CLASSES = "package_ipk"
+
 # Avoid adding these fields to RPM and DEP
 # breaking RPM builds as shown in http://errors.yoctoproject.org/Errors/Details/751706/
 PACKAGE_ADD_METADATA_RPM = ""


### PR DESCRIPTION
This PR includes 2 parts:
- webos_ls2_api_list.bbclass: Change LS2 API file path for API extraction, this help to fix build image without buildhistory
- webos.inc: avoid adding user-defined fields to packages and force PACKAGE_CLASSES to IPK, this help to solve the issue on AB (https://autobuilder.yoctoproject.org/typhoon/#/builders/163/builds/6)