### PR TITLE
webos: libpng=webos1 (fix file-rdeps QA issue about /bin/bash)

### DIFF
--- a/meta-webos/recipes-multimedia/libpng/libpng_%.bbappend
+++ b/meta-webos/recipes-multimedia/libpng/libpng_%.bbappend
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 LG Electronics, Inc.
+
+EXTENDPRAUTO:append = "webos1"
+
+# http://gecko.lge.com:8000/Errors/Details/1219896
+# ERROR: QA Issue: libpng-ptest rdepends on bash, but it isn't a build dependency, missing bash in DEPENDS or PACKAGECONFIG? [build-deps]
+VIRTUAL-RUNTIME_bash ?= "bash"
+RDEPENDS:${PN}-ptest:append:class-target = " ${VIRTUAL-RUNTIME_bash}"
+RDEPENDS:${PN}-ptest:remove:class-target = "${@oe.utils.conditional('WEBOS_PREFERRED_PROVIDER_FOR_BASH', 'busybox', 'bash', '', d)}"


### PR DESCRIPTION
:Release Notes:
Added in:
https://git.openembedded.org/openembedded-core/commit/?id=8dca5305c950e6a06b3f344ffdbbb7386d802095 and backported to scarthgap in:
https://git.openembedded.org/openembedded-core/commit/?h=scarthgap&id=1b52b7ebe5f8fb490088622181cdb95e6b7f5a29

:Detailed Notes:
Fixes:
http://gecko.lge.com:8000/Errors/Details/1219896
ERROR: QA Issue: libpng-ptest rdepends on bash, but it isn't a build dependency, missing bash in DEPENDS or PACKAGECONFIG? [build-deps]

:Testing Performed:
Only build tested.

:QA Notes:
No change to image.